### PR TITLE
sm8350-common: overlay: Allow user to select WiFi Calling while roaming

### DIFF
--- a/overlay/CarrierConfigResCommon/res/xml/vendor.xml
+++ b/overlay/CarrierConfigResCommon/res/xml/vendor.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <carrier_config_list>
     <carrier_config>
+        <boolean name="editable_wfc_roaming_mode_bool" value="true" />
         <boolean name="apn_expand_bool" value="true" />
         <boolean name="world_phone_bool" value="true" />
         <boolean name="allow_adding_apns_bool" value="true" />


### PR DESCRIPTION
This change means that by default the user has control over WiFi Calling while roaming unless otherwise specified within the carrier config.